### PR TITLE
Add error checking after stomp_send().

### DIFF
--- a/php_stomp.c
+++ b/php_stomp.c
@@ -549,8 +549,15 @@ PHP_FUNCTION(stomp_connect)
 			FRAME_HEADER_FROM_HASHTABLE(frame.headers, Z_ARRVAL_P(headers));
 		}
 
-		stomp_send(stomp, &frame TSRMLS_CC);
+		res = stomp_send(stomp, &frame TSRMLS_CC);
 		CLEAR_FRAME(frame);
+        if (0 == res) {
+            zval *excobj = zend_throw_exception_ex(stomp_ce_exception, stomp->errnum TSRMLS_CC, stomp->error);
+            if (stomp->error_details) {
+                zend_update_property_string(stomp_ce_exception, excobj, "details", sizeof("details")-1, stomp->error_details TSRMLS_CC);
+            }
+            return;
+        }
 
 		/* Retreive Response */
 		res = stomp_read_frame(stomp);


### PR DESCRIPTION
This one has been in there for a while and would hang for me in
1.0.6 release if the connection was refused.

Some tests would fail too. This error was also somewhat masked in
previous release (would get triggered when read() would expect 1 character and none were returned). 

We should abort and throw an exception if send fails.