### PR TITLE
Add content-length header only for messages containing zero byte

### DIFF
--- a/php_stomp.c
+++ b/php_stomp.c
@@ -747,6 +747,8 @@ PHP_FUNCTION(stomp_send)
 		CLEAR_FRAME(frame);
 		RETURN_FALSE;
 	}
+	if (frame.body_length > 0 && strnlen(frame.body, frame.body_length) >= frame.body_length)
+		frame.body_length = 0;
 
 	if (stomp_send(stomp, &frame TSRMLS_CC) > 0) {
 		success = stomp_valid_receipt(stomp, &frame);

--- a/php_stomp.c
+++ b/php_stomp.c
@@ -531,6 +531,7 @@ PHP_FUNCTION(stomp_connect)
 
 	if (stomp->status) {
 		stomp_frame_t *res;
+		int rres;
 		stomp_frame_t frame = {0};
  
 		INIT_FRAME(frame, "CONNECT");
@@ -549,9 +550,9 @@ PHP_FUNCTION(stomp_connect)
 			FRAME_HEADER_FROM_HASHTABLE(frame.headers, Z_ARRVAL_P(headers));
 		}
 
-		res = stomp_send(stomp, &frame TSRMLS_CC);
+		rres = stomp_send(stomp, &frame TSRMLS_CC);
 		CLEAR_FRAME(frame);
-		if (0 == res) {
+		if (0 == rres) {
 			zval *excobj = zend_throw_exception_ex(stomp_ce_exception, stomp->errnum TSRMLS_CC, stomp->error);
 			if (stomp->error_details) {
 				zend_update_property_string(stomp_ce_exception, excobj, "details", sizeof("details")-1, stomp->error_details TSRMLS_CC);


### PR DESCRIPTION
Hi!

Now php5-stomp always adds 'content-length' header to all messages being sent. This makes sending JMS "TextMessage" (including XML!) impossible, because most JMS/STOMP queues like OpenMQ or ActiveMQ decide whether the message is JMS "BytesMessage" or "TextMessage" based on the presence of 'content-length' header (as described here: http://activemq.apache.org/stomp.html and here: https://mq.java.net/4.4-content/stomp-funcspec.html). I.e. if it is there, the message is treated as bytes. So JMS can never decode messages sent from php5-stomp as XML, because it wants XML to be TextMessages.

And XML is obviously the thing that you want the most when connecting to a JMS queue via STOMP! :)

This pull request fixes this behaviour by making php5-stomp only add content-length header for messages with zero byte.

(https://bugs.php.net/bug.php?id=70280)
