### PR TITLE
Remove inactive 3rd argument in PHP_SETUP_OPENSSL

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -12,15 +12,8 @@ if test "$PHP_STOMP" != "no"; then
   test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
 
   if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
-    PHP_SETUP_OPENSSL(STOMP_SHARED_LIBADD,
-            [
-            AC_DEFINE(HAVE_STOMP_SSL,1,[ ])
-            ], [
-            AC_MSG_ERROR([OpenSSL libraries not found.
-
-                Check the path given to --with-openssl-dir and output in config.log)
-            ])
-    ])
+    PHP_SETUP_OPENSSL([STOMP_SHARED_LIBADD],
+      [AC_DEFINE([HAVE_STOMP_SSL], [1], [ ])])
 
     PHP_SUBST(STOMP_SHARED_LIBADD)
   fi


### PR DESCRIPTION
The upstream PHP_SETUP_OPENSSL has 3rd argument inactive. If OpenSSL is not found using pkg-config, it always errors out by default. Fix has been addressed in PHP-8.4-dev upstream by removing the 3rd argument: https://github.com/php/php-src/pull/14323